### PR TITLE
Implement skeleton for research assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Domain-Aware Research Assistant (Skeleton)
+
+This repository contains a minimal prototype of a research assistant using Retrieval-Augmented Generation (RAG) with the Mistral 7B model. The pipeline covers:
+
+1. **Data ingestion** from a directory of text files.
+2. **Vector indexing** of text chunks with FAISS and Sentence Transformers.
+3. **RAG inference** that retrieves relevant passages and generates an answer.
+4. **Optional LoRA fine-tuning** utilities using `peft`.
+5. **FastAPI web app** exposing a `/ask` endpoint.
+
+## Usage
+
+1. Place your `.txt` documents in the `corpus/` directory.
+2. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Run the API server:
+
+```bash
+uvicorn webapp.app:app --reload
+```
+
+Send a POST request to `/ask` with a JSON body `{"question": "..."}`.
+
+Model weights are loaded from Hugging Face and may require a GPU for efficient inference.

--- a/data_ingest/__init__.py
+++ b/data_ingest/__init__.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Iterable
+
+@dataclass
+class Document:
+    text: str
+    source: str
+
+
+def load_texts(directory: str) -> List[Document]:
+    """Load .txt files from a directory."""
+    docs = []
+    for path in Path(directory).rglob('*.txt'):
+        text = path.read_text(encoding='utf-8')
+        docs.append(Document(text=text, source=str(path)))
+    return docs
+
+
+def chunk_document(doc: Document, chunk_size: int = 500, overlap: int = 50) -> Iterable[Document]:
+    """Yield overlapping chunks from a document."""
+    words = doc.text.split()
+    start = 0
+    while start < len(words):
+        end = start + chunk_size
+        chunk_text = ' '.join(words[start:end])
+        yield Document(text=chunk_text, source=doc.source)
+        start = end - overlap

--- a/indexing/__init__.py
+++ b/indexing/__init__.py
@@ -1,0 +1,28 @@
+from typing import List
+import faiss
+from sentence_transformers import SentenceTransformer
+
+from data_ingest import Document
+
+class VectorIndex:
+    def __init__(self, model_name: str = 'sentence-transformers/all-MiniLM-L6-v2'):
+        self.model = SentenceTransformer(model_name)
+        self.index = None
+        self.docs: List[Document] = []
+
+    def build(self, docs: List[Document]):
+        embeddings = self.model.encode([d.text for d in docs], show_progress_bar=True)
+        dim = embeddings.shape[1]
+        self.index = faiss.IndexFlatL2(dim)
+        self.index.add(embeddings)
+        self.docs = docs
+
+    def query(self, question: str, k: int = 3):
+        if self.index is None:
+            raise ValueError('Index not built')
+        q_emb = self.model.encode([question])
+        distances, indices = self.index.search(q_emb, k)
+        results = []
+        for dist, idx in zip(distances[0], indices[0]):
+            results.append({'doc': self.docs[idx], 'score': float(dist)})
+        return results

--- a/inference/finetune.py
+++ b/inference/finetune.py
@@ -1,0 +1,30 @@
+from typing import List
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import LoraConfig, get_peft_model, TaskType
+from datasets import Dataset
+
+
+def prepare_dataset(pairs: List[dict]):
+    return Dataset.from_list(pairs)
+
+
+def finetune_lora(model_name: str, qa_pairs: List[dict], output_dir: str):
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+
+    config = LoraConfig(task_type=TaskType.CAUSAL_LM, r=8, lora_alpha=16, lora_dropout=0.1)
+    model = get_peft_model(model, config)
+
+    ds = prepare_dataset(qa_pairs)
+    ds = ds.map(lambda ex: tokenizer(ex['prompt'], truncation=True), batched=True)
+
+    model.train()
+    for epoch in range(3):  # tiny example
+        for batch in ds:
+            outputs = model(**batch, labels=batch['input_ids'])
+            loss = outputs.loss
+            loss.backward()
+            model.optimizer.step()
+            model.zero_grad()
+
+    model.save_pretrained(output_dir)

--- a/inference/rag.py
+++ b/inference/rag.py
@@ -1,0 +1,31 @@
+from typing import List
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from data_ingest import Document
+from indexing import VectorIndex
+
+
+def load_model(model_name: str = 'mistralai/Mistral-7B-v0.1'):
+    """Load Mistral model and tokenizer."""
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    return tokenizer, model
+
+
+def format_prompt(question: str, passages: List[Document]) -> str:
+    snippet_text = "\n\n".join(f"[Source: {p.source}]\n{p.text}" for p in passages)
+    prompt = (
+        "You are an expert research assistant. Use the passages below to answer the question.\n"
+        f"{snippet_text}\n\nQuestion: {question}\nAnswer:"
+    )
+    return prompt
+
+
+def generate_answer(question: str, index: VectorIndex, tokenizer, model, k: int = 3):
+    results = index.query(question, k)
+    passages = [r['doc'] for r in results]
+    prompt = format_prompt(question, passages)
+    inputs = tokenizer(prompt, return_tensors='pt')
+    output = model.generate(**inputs, max_new_tokens=200)
+    answer = tokenizer.decode(output[0], skip_special_tokens=True)
+    return answer, results

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+faiss-cpu
+sentence-transformers
+transformers
+peft
+datasets
+fastapi
+uvicorn

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from data_ingest import load_texts, chunk_document
+from indexing import VectorIndex
+from inference.rag import load_model, generate_answer
+
+app = FastAPI()
+
+class Query(BaseModel):
+    question: str
+
+
+@app.on_event('startup')
+def startup_event():
+    global index, tokenizer, model
+    docs = []
+    for doc in load_texts('corpus'):
+        docs.extend(list(chunk_document(doc)))
+    index = VectorIndex()
+    if docs:
+        index.build(docs)
+    tokenizer, model = load_model()
+
+
+@app.post('/ask')
+def ask(query: Query):
+    answer, passages = generate_answer(query.question, index, tokenizer, model)
+    return {
+        'answer': answer,
+        'sources': [{'source': p['doc'].source, 'score': p['score']} for p in passages]
+    }


### PR DESCRIPTION
## Summary
- add data ingestion utilities for loading and chunking text
- build FAISS vector index and query interface
- provide RAG-based answer generation with Mistral
- include LoRA fine-tuning helper
- expose a FastAPI app with `/ask` endpoint
- document usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68572e2c8c648320aa57ff8598350b33